### PR TITLE
Added reference to Microsoft.Extensions.Configuration.Binder in Confi…

### DIFF
--- a/sources/ConfigurationManager/packages.config
+++ b/sources/ConfigurationManager/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="Microsoft.Extensions.Configuration" version="1.0.0-rc1-final" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.0-rc1-final" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="1.0.0-rc1-final" targetFramework="net451" />
   <package id="Microsoft.Extensions.Primitives" version="1.0.0-rc1-final" targetFramework="net451" />
 </packages>

--- a/sources/Octopus/packages.config
+++ b/sources/Octopus/packages.config
@@ -3,6 +3,7 @@
   <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration" version="1.0.0-rc1-final" targetFramework="net451" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.0-rc1-final" targetFramework="net451" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="1.0.0-rc1-final" targetFramework="net451" />
   <package id="Microsoft.Extensions.Primitives" version="1.0.0-rc1-final" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="Octopus.Client" version="3.2.11" targetFramework="net451" />


### PR DESCRIPTION
I had to add a reference to Microsoft.Extensions.Configuration.Binder in my projects separately as it was not included in ConfigurationManager and Octopus packages. Otherwise extension methods like ConfigurationRoot.Get cannot be resolved compile-time.
